### PR TITLE
Xorg fonts

### DIFF
--- a/bdftopcf/plan.sh
+++ b/bdftopcf/plan.sh
@@ -1,0 +1,18 @@
+#
+# This package is NOT officially support by the Xorg project.  Please
+# report bugs related to this package on GitHub:
+#
+# https://github.com/stevendanna/habitat-plans
+#
+pkg_name=bdftopcf
+pkg_origin=xorg
+pkg_version=1.0.3
+pkg_maintainer="Steven Danna <steve@chef.io>"
+pkg_description="X.Org Applications: bdftopcf"
+pkg_upstream_url="https://www.x.org/"
+pkg_license=('MIT')
+pkg_source="https://www.x.org/releases/current/src/everything/${pkg_name}-${pkg_version}.tar.bz2"
+pkg_shasum=9c90b408b2fe079495697bfc8fb13da940b2b70f4907213bf5dcc9e3024a1d0a
+pkg_deps=(core/glibc core/freetype core/zlib core/bzip2 core/libpng xorg/libfontenc xorg/libxfont)
+pkg_build_deps=(core/gcc core/make core/pkg-config xorg/util-macros xorg/xproto xorg/fontsproto)
+pkg_bin_dirs=(bin)

--- a/font-bitstream-type1/plan.sh
+++ b/font-bitstream-type1/plan.sh
@@ -1,0 +1,28 @@
+#
+# This package is NOT officially support by the Xorg project.  Please
+# report bugs related to this package on GitHub:
+#
+# https://github.com/stevendanna/habitat-plans
+#
+pkg_name=font-bitstream-type1
+pkg_origin=xorg
+pkg_version=1.0.3
+pkg_maintainer="Steven Danna <steve@chef.io>"
+pkg_description="X.Org Fonts: font bitstream type1"
+pkg_upstream_url="https://www.x.org/"
+pkg_license=('MIT')
+pkg_source="https://www.x.org/releases/current/src/everything/${pkg_name}-${pkg_version}.tar.bz2"
+pkg_shasum=c6ea0569adad2c577f140328dc3302e729cb1b1ea90cd0025caf380625f8a688
+pkg_build_deps=(core/gcc core/make core/pkg-config xorg/util-macros xorg/mkfontdir xorg/mkfontscale xorg/font-util xorg/bdftopcf)
+pkg_include_dirs=(include)
+pkg_lib_dirs=(lib)
+pkg_bin_dirs=(bin)
+
+do_build() {
+  ./configure --prefix="${pkg_prefix}" \
+              --sysconfdir="${pkg_prefix}/etc" \
+              --localstatedir="${pkg_prefix}/var" \
+              --with-fontrootdir="${pkg_prefix}/share/fonts/X11"
+
+  make
+}

--- a/font-util/plan.sh
+++ b/font-util/plan.sh
@@ -1,0 +1,19 @@
+#
+# This package is NOT officially support by the Xorg project.  Please
+# report bugs related to this package on GitHub:
+#
+# https://github.com/stevendanna/habitat-plans
+#
+pkg_name=font-util
+pkg_origin=xorg
+pkg_version=1.3.0
+pkg_maintainer="Steven Danna <steve@chef.io>"
+pkg_description="X.Org font package creation/installation utilities"
+pkg_upstream_url="https://www.x.org/"
+pkg_license=('MIT')
+pkg_source="https://www.x.org/releases/current/src/everything/${pkg_name}-${pkg_version}.tar.bz2"
+pkg_shasum=dfa9e55625a4e0250f32fabab1fd5c8ffcd2d1ff2720d6fcf0f74bc8a5929195
+pkg_deps=(core/glibc)
+pkg_build_deps=(core/gcc core/make core/pkg-config xorg/util-macros)
+pkg_lib_dirs=(lib)
+pkg_bin_dirs=(bin)

--- a/fontconfig/plan.sh
+++ b/fontconfig/plan.sh
@@ -1,0 +1,56 @@
+pkg_name=fontconfig
+pkg_version=2.11.94
+pkg_origin=core
+pkg_license=('fontconfig')
+pkg_description="Fontconfig is a library for configuring and
+  customizing font access."
+pkg_upstream_url=https://www.freedesktop.org/wiki/Software/fontconfig/
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_source=https://www.freedesktop.org/software/fontconfig/release/${pkg_name}-${pkg_version}.tar.bz2
+pkg_filename=${pkg_name}-${pkg_version}.tar.bz2
+pkg_shasum=d763c024df434146f3352448bc1f4554f390c8a48340cef7aa9cc44716a159df
+pkg_deps=(
+  core/bzip2
+  core/glibc
+  core/zlib
+)
+pkg_build_deps=(core/gcc core/make core/coreutils core/python
+                core/pkg-config core/freetype core/expat
+                core/diffutils core/libtool core/m4 core/automake
+                core/autoconf core/file)
+pkg_include_dirs=(include)
+pkg_lib_dirs=(lib)
+pkg_bin_dirs=(bin)
+
+do_prepare() {
+  # Set freetype paths
+  export FREETYPE_CFLAGS="$CFLAGS"
+  build_line "Setting FREETYPE_CFLAGS=$FREETYPE_CFLAGS"
+  export FREETYPE_LIBS
+  FREETYPE_LIBS="$LDFLAGS -Wl,--rpath -Wl,$(pkg_path_for freetype)/lib -lfreetype -lz"
+  build_line "Setting FREETYPE_LIBS=$FREETYPE_LIBS"
+
+  # Add "freetype2" to include path
+  export CFLAGS
+  CFLAGS="$CFLAGS -I$(pkg_path_for freetype)/include/freetype2"
+  build_line "Setting CFLAGS=$CFLAGS"
+
+  # Borrowing this pro tip from ArchLinux!
+  # https://projects.archlinux.org/svntogit/packages.git/tree/trunk/PKGBUILD?h=packages/fontconfig#n34
+  # this seems to run libtoolize though...
+  autoreconf -fi
+
+  _file_path="$(pkg_path_for file)/bin/file"
+  _uname_path="$(pkg_path_for coreutils)/bin/uname"
+
+  sed -e "s#/usr/bin/file#${_file_path}#g" -i configure
+  sed -e "s#/usr/bin/uname#${_uname_path}#g" -i configure
+}
+
+do_build() {
+  ./configure --sysconfdir="$pkg_prefix/etc" \
+              --prefix="$pkg_prefix" \
+              --disable-static \
+              --mandir="$pkg_prefix/man"
+  make
+}

--- a/fontconfig/plan.sh
+++ b/fontconfig/plan.sh
@@ -13,11 +13,14 @@ pkg_deps=(
   core/bzip2
   core/glibc
   core/zlib
+  core/freetype
+  core/libpng
+  core/expat
+  core/gcc-libs
 )
 pkg_build_deps=(core/gcc core/make core/coreutils core/python
-                core/pkg-config core/freetype core/expat
-                core/diffutils core/libtool core/m4 core/automake
-                core/autoconf core/file)
+                core/pkg-config core/diffutils core/libtool
+                core/m4 core/automake core/autoconf core/file)
 pkg_include_dirs=(include)
 pkg_lib_dirs=(lib)
 pkg_bin_dirs=(bin)

--- a/fontsproto/plan.sh
+++ b/fontsproto/plan.sh
@@ -1,0 +1,19 @@
+#
+# This package is NOT officially support by the Xorg project.  Please
+# report bugs related to this package on GitHub:
+#
+# https://github.com/stevendanna/habitat-plans
+#
+pkg_name=fontsproto
+pkg_origin=xorg
+pkg_version=2.1.2
+pkg_maintainer="Steven Danna <steve@chef.io>"
+pkg_description="X.Org Protocol Headers: fontsproto"
+pkg_upstream_url="https://www.x.org/"
+pkg_license=('MIT')
+pkg_source="https://www.x.org/releases/current/src/everything/${pkg_name}-${pkg_version}.tar.bz2"
+pkg_shasum=869c97e5a536a8f3c9bc8b9923780ff1f062094bab935e26f96df3d6f1aa68a9
+pkg_deps=(core/glibc)
+pkg_build_deps=(core/gcc core/make core/pkg-config xorg/util-macros)
+pkg_include_dirs=(include)
+pkg_lib_dirs=(lib)

--- a/libfontenc/plan.sh
+++ b/libfontenc/plan.sh
@@ -1,0 +1,19 @@
+#
+# This package is NOT officially support by the Xorg project.  Please
+# report bugs related to this package on GitHub:
+#
+# https://github.com/stevendanna/habitat-plans
+#
+pkg_name=libfontenc
+pkg_origin=xorg
+pkg_version=1.1.1
+pkg_maintainer="Steven Danna <steve@chef.io>"
+pkg_description="X.Org Libraries: libfontenc"
+pkg_upstream_url="https://www.x.org/"
+pkg_license=('MIT')
+pkg_source="https://www.x.org/releases/current/src/everything/${pkg_name}-${pkg_version}.tar.bz2"
+pkg_shasum=de72812f1856bb63bd2226ec8c2e2301931d3c72bd0f08b0d63a0cdf0722017f
+pkg_deps=(core/glibc core/zlib)
+pkg_build_deps=(core/gcc core/make core/pkg-config xorg/xproto)
+pkg_include_dirs=(include)
+pkg_lib_dirs=(lib)

--- a/libxfont/plan.sh
+++ b/libxfont/plan.sh
@@ -1,0 +1,21 @@
+#
+# This package is NOT officially support by the Xorg project.  Please
+# report bugs related to this package on GitHub:
+#
+# https://github.com/stevendanna/habitat-plans
+#
+pkg_name=libxfont
+pkg_distname=libXfont
+pkg_origin=xorg
+pkg_version=1.4.5
+pkg_dirname="${pkg_distname}-${pkg_version}"
+pkg_maintainer="Steven Danna <steve@chef.io>"
+pkg_description="X.Org Libraries: libXfont"
+pkg_upstream_url="https://www.x.org/"
+pkg_license=('MIT')
+pkg_source="https://www.x.org/releases/current/src/everything/${pkg_distname}-${pkg_version}.tar.bz2"
+pkg_shasum=bbf96fb80b6b95cdb1dc968085082a6e668193a54cd9d6e2af669909c0cb7170
+pkg_deps=(core/glibc core/freetype core/zlib core/bzip2 core/libpng xorg/libfontenc)
+pkg_build_deps=(core/gcc core/make core/pkg-config xorg/xproto xorg/xtrans xorg/fontsproto)
+pkg_include_dirs=(include)
+pkg_lib_dirs=(lib)

--- a/mkfontdir/plan.sh
+++ b/mkfontdir/plan.sh
@@ -1,0 +1,18 @@
+#
+# This package is NOT officially support by the Xorg project.  Please
+# report bugs related to this package on GitHub:
+#
+# https://github.com/stevendanna/habitat-plans
+#
+pkg_name=mkfontdir
+pkg_origin=xorg
+pkg_version=1.0.7
+pkg_maintainer="Steven Danna <steve@chef.io>"
+pkg_description="X.Org Applications: mkfontdir"
+pkg_upstream_url="https://www.x.org/"
+pkg_license=('MIT')
+pkg_source="https://www.x.org/releases/current/src/everything/${pkg_name}-${pkg_version}.tar.bz2"
+pkg_shasum=56d52a482df130484e51fd066d1b6eda7c2c02ddbc91fe6e2be1b9c4e7306530
+pkg_deps=(xorg/mkfontscale)
+pkg_build_deps=(core/gcc core/make)
+pkg_bin_dirs=(bin)

--- a/mkfontscale/plan.sh
+++ b/mkfontscale/plan.sh
@@ -1,0 +1,18 @@
+#
+# This package is NOT officially support by the Xorg project.  Please
+# report bugs related to this package on GitHub:
+#
+# https://github.com/stevendanna/habitat-plans
+#
+pkg_name=mkfontscale
+pkg_origin=xorg
+pkg_version=1.1.0
+pkg_maintainer="Steven Danna <steve@chef.io>"
+pkg_description="X.Org Applications: mkfontdir"
+pkg_upstream_url="https://www.x.org/"
+pkg_license=('MIT')
+pkg_source="https://www.x.org/releases/current/src/everything/${pkg_name}-${pkg_version}.tar.bz2"
+pkg_shasum=ce55f862679b8ec127d7f7315ac04a8d64a0d90a0309a70dc56c1ba3f9806994
+pkg_deps=(core/glibc core/zlib core/freetype xorg/libfontenc)
+pkg_build_deps=(core/gcc core/make core/pkg-config core/libpng xorg/xproto)
+pkg_bin_dirs=(bin)


### PR DESCRIPTION
font-bitstream-type1 fails to build if `core/font-config` is a dependency